### PR TITLE
Handle BOM and other issues found in forum issue

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -90,7 +90,10 @@ function getProtocolAndPath(path, relativeTo) {
   }
 }
 const parseProtocol = (photo, baseDirectory) => {
-  const rawPath = photo[`${TROPY}#path`][0]['@value']
+  const rawPath = photo[`${TROPY}#path`]?.[0]['@value']
+  if (!rawPath) {
+    return photo
+  }
   const { protocol, path } = getProtocolAndPath(rawPath, baseDirectory)
   photo[`${TROPY}#path`][0]['@value'] = path
   Object.assign(photo, createValue(`${TROPY}#protocol`, protocol))

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -46,7 +46,7 @@ const createNoteValue = (k, v, sep = ' --- ') => {
 }
 
 const createValue = (k, v) => {
-  if (!v) return
+  if (!v) return {}
   switch (k) {
     case (`${TROPY}#note`):
       return createNoteValue(k, v)

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -203,15 +203,15 @@ class CSVPlugin {
       for (let p of photos) {
         let photoData = Object.assign(
           ...p.map((v, idx) => createValue(photoKeys[idx], v))
-        );
+        )
         if (photoData[`${TROPY}#path`] !== undefined) {
-          parseProtocol(photoData, baseDirectory);
+          parseProtocol(photoData, baseDirectory)
           item.photo.push(
             addTemplateKey(photoData, this.options.photoTemplate)
-          );
+          )
         } else {
           // Don't fail if there's no TROPY/#path values for that row
-          console.warn("No photo paths parsed for row", row)
+          console.warn('No photo paths parsed for row', row)
         }
       }
     }
@@ -236,8 +236,8 @@ class CSVPlugin {
           relaxColumnCount: true,
           delimiter: this.options.delimiter,
           bom: true,
-          skipEmptyLines: true,
-        });
+          skipEmptyLines: true
+        })
         const headerRow = this.options.customHeaders ?
           parse(this.options.customHeaders,
             { delimiter: this.options.delimiter }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -203,9 +203,16 @@ class CSVPlugin {
       for (let p of photos) {
         let photoData = Object.assign(
           ...p.map((v, idx) => createValue(photoKeys[idx], v))
-        )
-        parseProtocol(photoData, baseDirectory)
-        item.photo.push(addTemplateKey(photoData, this.options.photoTemplate))
+        );
+        if (photoData[`${TROPY}#path`] !== undefined) {
+          parseProtocol(photoData, baseDirectory);
+          item.photo.push(
+            addTemplateKey(photoData, this.options.photoTemplate)
+          );
+        } else {
+          // Don't fail if there's no TROPY/#path values for that row
+          console.warn("No photo paths parsed for row", row)
+        }
       }
     }
     return item

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -225,10 +225,12 @@ class CSVPlugin {
 
     for (const file of files) {
       try {
-        const csvRows = parse(
-          await readFile(file),
-          { relaxColumnCount: true, delimiter: this.options.delimiter }
-        )
+        const csvRows = parse(await readFile(file), {
+          relaxColumnCount: true,
+          delimiter: this.options.delimiter,
+          bom: true,
+          skipEmptyLines: true,
+        });
         const headerRow = this.options.customHeaders ?
           parse(this.options.customHeaders,
             { delimiter: this.options.delimiter }

--- a/test/import_row_test.js
+++ b/test/import_row_test.js
@@ -31,6 +31,17 @@ const rowManyPhoto = [
   (platform === 'win32') ? 'D:\\user\\photo2.jpg' : '/home/user/photo2.jpg',
   'some note --- another note, with a comma']
 
+const rowMissingPhoto = [
+  '2022-01-04',
+  'title2',
+  'tag2',
+  (platform === 'win32') ? 'D:\\user\\photo1.jpg' : '/home/user/photo1.jpg',
+  'a note',
+  (platform === 'win32') ? 'D:\\user\\photo2.jpg' : '/home/user/photo2.jpg',
+  'some note --- another note, with a comma',
+  // No photo path provided
+'',  'this note should be dropped?']
+
 function generatePhoto(path, note = null, protocol = 'file') {
   const photo = {
     'https://tropy.org/v1/tropy#path': [{ '@value': path }],
@@ -81,6 +92,11 @@ describe('Parse row', () => {
     assert.equal(actual.photo.length, 2)
     assert.deepEqual(actual['photo'][0],
       generatePhoto(rowManyPhoto[3], rowManyPhoto[4]))
+  })
+  it('Photo and note not imported if no path for photos', () => {
+    const actual = plugin.parseRow(rowMissingPhoto, itemHeaders, photoHeaders)
+    assert.equal(actual.photo.length, 2)
+    assert.equal(JSON.stringify(actual).includes('this note should be dropped?'),false)
   })
   it('Photo has no notes if notes not present in CSV', () => {
     const actual = plugin.parseRow(rowSinglePhoto, itemHeaders, photoHeaders)

--- a/test/import_row_test.js
+++ b/test/import_row_test.js
@@ -15,7 +15,7 @@ const photoHeaders = [
   `${TROPY}#note`
 ]
 const rowNoPhoto = ['2022-01-02', 'title', '']
-const rowNoTitle = ['2022-01-02', '', '']
+const rowNoDate = ['', 'title', '']
 const rowSinglePhoto = [
   '2022-01-03',
   'title1',
@@ -62,9 +62,9 @@ describe('Parse row', () => {
     assert.deepEqual(actual, generateExpectedItem(rowNoPhoto[0], rowNoPhoto[1]))
   })
   it('Does not add key to item if value is empty in csv', () => {
-    const actual = plugin.parseRow(rowNoTitle, itemHeaders, photoHeaders)
-    assert.equal(actual['http://purl.org/dc/terms/title'], undefined)
-    assert.ok(actual['http://purl.org/dc/elements/1.1/date'] !== undefined)
+    const actual = plugin.parseRow(rowNoDate, itemHeaders, photoHeaders)
+    assert.ok(actual['http://purl.org/dc/terms/title'] !== undefined)
+    assert.equal(actual['http://purl.org/dc/elements/1.1/date'], undefined)
   })
   it('Item has no photos if no photo headers present', () => {
     const actual = plugin.parseRow(rowSinglePhoto, itemHeaders, undefined)

--- a/test/import_row_test.js
+++ b/test/import_row_test.js
@@ -40,7 +40,7 @@ const rowMissingPhoto = [
   (platform === 'win32') ? 'D:\\user\\photo2.jpg' : '/home/user/photo2.jpg',
   'some note --- another note, with a comma',
   // No photo path provided
-'',  'this note should be dropped?']
+  '',  'this note should be dropped?']
 
 function generatePhoto(path, note = null, protocol = 'file') {
   const photo = {
@@ -96,7 +96,10 @@ describe('Parse row', () => {
   it('Photo and note not imported if no path for photos', () => {
     const actual = plugin.parseRow(rowMissingPhoto, itemHeaders, photoHeaders)
     assert.equal(actual.photo.length, 2)
-    assert.equal(JSON.stringify(actual).includes('this note should be dropped?'),false)
+    assert.equal(
+      JSON.stringify(actual).includes('This note should be dropped?'),
+      false
+    )
   })
   it('Photo has no notes if notes not present in CSV', () => {
     const actual = plugin.parseRow(rowSinglePhoto, itemHeaders, photoHeaders)


### PR DESCRIPTION
Forum post: https://forums.tropy.org/t/import-metadata-from-csv/2784/5

Things that were broken
- plugin didn't handle files with BOM at all. This is just an option in the CSV parsing library I'd forgotten to add
- plugin broke when there was a missing value in a TROPY/#path column (corresponding to a missing photo filename) because it couldn't get the file extension of `undefined`. This is fixed by checking the path is defined when trying to construct a photo
- plugin broke when some columns were empty, fixed by returning an empty object in these cases, rather than undefined (#23)

I'm sure there's better ways to handle at least the last 2 issues, but this was the best I could think of now.